### PR TITLE
Add pre-commit hook and development tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,18 @@ permissions:
   contents: read
 
 jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go install golang.org/x/tools/cmd/goimports@latest
+      - name: Check formatting
+        run: |
+          test -z "$(goimports -l .)"
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/AGENT.md
+++ b/AGENT.md
@@ -5,8 +5,10 @@ Go CLI that auto-detects npm/yarn/pnpm and proxies commands.
 ## Development
 
 ```bash
-go test ./... -v -race   # run tests
-go build -o spm .        # build
+just setup               # install git hooks and dev tools
+just test                # run tests
+just fmt                 # format all Go files
+just build               # build binary
 ```
 
 ## Conventions
@@ -14,4 +16,5 @@ go build -o spm .        # build
 - **Changelog**: Always update `CHANGELOG.md` when making user-facing changes. Add entries under `[Unreleased]` using the appropriate category (Added, Changed, Deprecated, Removed, Fixed, Security). Follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 - **README**: Keep `README.md` up to date when adding new commands, flags, or changing behavior.
 - **Tests**: Add or update tests for any new functionality in the corresponding `_test.go` files.
-- **CI**: GitHub Actions runs `go test ./... -v -race` and cross-platform builds on every PR.
+- **Formatting**: A pre-commit hook runs `goimports` on staged Go files. Run `just setup` after cloning.
+- **CI**: GitHub Actions runs `go test ./... -v -race`, format checks, and cross-platform builds on every PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Pre-commit hook to auto-format Go code and organize imports via `goimports`.
+- `justfile` with `setup`, `fmt`, `test`, and `build` recipes.
+- CI format check job to catch unformatted code.
 - Tests for `cmd`, `runner`, and `prompt` packages.
 
 ## [0.1.0] - 2026-03-11

--- a/README.md
+++ b/README.md
@@ -72,19 +72,24 @@ Found a bug or have a question? [Open an issue](https://github.com/decampsrenan/
 
 ## Contributing
 
+Requires [Go](https://go.dev/) 1.25+ and [just](https://github.com/casey/just).
+
 ```sh
 # Clone the repository
 git clone https://github.com/decampsrenan/spm.git
 cd spm
 
-# Install dependencies
-go mod download
+# Install dev tools and git hooks
+just setup
 
 # Run tests
-go test ./...
+just test
+
+# Format code
+just fmt
 
 # Build
-go build -o spm .
+just build
 ```
 
 ## License

--- a/justfile
+++ b/justfile
@@ -1,0 +1,22 @@
+# Install git hooks and dev tools
+setup:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    go install golang.org/x/tools/cmd/goimports@latest
+    HOOKS_DIR="$(git rev-parse --git-path hooks)"
+    mkdir -p "$HOOKS_DIR"
+    cp scripts/pre-commit "$HOOKS_DIR/pre-commit"
+    chmod +x "$HOOKS_DIR/pre-commit"
+    echo "Git hooks installed."
+
+# Format all Go files
+fmt:
+    goimports -w .
+
+# Run tests
+test:
+    go test ./... -v -race
+
+# Build binary
+build:
+    go build -o spm .

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get staged .go files (only Added/Copied/Modified, not deleted)
+STAGED_GO_FILES=$(git diff --cached --name-only --diff-filter=ACM -- '*.go')
+
+if [ -z "$STAGED_GO_FILES" ]; then
+    exit 0
+fi
+
+# Check goimports is installed
+if ! command -v goimports &>/dev/null; then
+    echo "goimports not found. Run: just setup"
+    exit 1
+fi
+
+# Format staged files and re-add them
+echo "$STAGED_GO_FILES" | xargs goimports -w
+echo "$STAGED_GO_FILES" | xargs git add
+
+echo "pre-commit: goimports applied."


### PR DESCRIPTION
Introduces a `goimports` pre-commit hook to automatically format Go code and organize imports on each commit. Adds a `justfile` for common development tasks (setup, test, fmt, build) and a CI format-check job to catch unformatted code. Updates AGENT.md, README.md, and CHANGELOG.md to reflect the new conventions and tooling.