### PR TITLE
Add MIT license and fix flag parsing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Renan Decamps
+Copyright (c) 2026 Renan Decamps
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,10 @@ var addCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Print command instead of executing it")
+	// Allow unknown flags to pass through to the underlying package manager
+	// (e.g. spm add react --save-dev, spm dev --port 3000)
+	rootCmd.FParseErrWhitelist.UnknownFlags = true
+	addCmd.FParseErrWhitelist.UnknownFlags = true
 	rootCmd.AddCommand(installCmd)
 	rootCmd.AddCommand(addCmd)
 }


### PR DESCRIPTION
## Summary

- Add MIT license file with 2026 copyright
- Fix Cobra flag parsing to allow unknown flags to pass through to the underlying package manager

This enables documented usage patterns like `spm add react --save-dev` and `spm dev --port 3000` by whitelisting unknown flags on rootCmd and addCmd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)