### PR TITLE
Add changelog validation and automated versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,16 @@ jobs:
         with:
           go-version-file: go.mod
       - run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 go build -o spm .
+
+  changelog:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check CHANGELOG has unreleased entries
+        run: |
+          CONTENT=$(sed -n '/^## \[Unreleased\]/,/^## \[/p' CHANGELOG.md | tail -n +2 | sed '$d')
+          if ! echo "$CONTENT" | grep -q '^ *- '; then
+            echo "::error::No entries found in [Unreleased] section of CHANGELOG.md. Please document your changes."
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'chore: release')"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,8 +20,8 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Bump version and push tag
-        id: tag
+      - name: Compute next version
+        id: version
         run: |
           git fetch --tags
           LATEST=$(git tag -l 'v*' --sort=-v:refname | head -n1)
@@ -32,9 +33,25 @@ jobs:
             PATCH=$(echo "$LATEST" | sed 's/v//' | cut -d. -f3)
             NEXT="v${MAJOR}.${MINOR}.$((PATCH + 1))"
           fi
-          git tag "$NEXT"
-          git push origin "$NEXT"
           echo "tag=$NEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Update CHANGELOG
+        run: |
+          bash scripts/update-changelog.sh "${{ steps.version.outputs.tag }}"
+          if git diff --quiet CHANGELOG.md; then
+            echo "No CHANGELOG changes to commit."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add CHANGELOG.md
+            git commit -m "chore: release ${{ steps.version.outputs.tag }}"
+            git push origin main
+          fi
+
+      - name: Tag and push
+        run: |
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
 
       - uses: goreleaser/goreleaser-action@v6
         with:

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Updates CHANGELOG.md by moving [Unreleased] entries into a new versioned section.
+# Usage: ./scripts/update-changelog.sh v0.2.0
+
+VERSION="$1"
+VERSION_NUM="${VERSION#v}"
+DATE=$(date +%Y-%m-%d)
+FILE="CHANGELOG.md"
+
+# Check that [Unreleased] section has entries
+UNRELEASED=$(sed -n '/^## \[Unreleased\]/,/^## \[/p' "$FILE" | tail -n +2 | sed '$d')
+if ! echo "$UNRELEASED" | grep -q '^ *- '; then
+  echo "No unreleased entries found, skipping CHANGELOG update."
+  exit 0
+fi
+
+# Find previous version tag from CHANGELOG headings
+PREV_VERSION=$(grep -oE '## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$FILE" | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+
+# Replace [Unreleased] section: insert empty [Unreleased] + new version heading
+awk -v ver="$VERSION_NUM" -v date="$DATE" '
+BEGIN { in_unreleased = 0; printed_new = 0 }
+/^## \[Unreleased\]/ {
+  print "## [Unreleased]"
+  print ""
+  in_unreleased = 1
+  next
+}
+in_unreleased && /^## \[/ {
+  printf "## [%s] - %s\n", ver, date
+  print ""
+  in_unreleased = 0
+  printed_new = 1
+}
+in_unreleased {
+  # Buffer unreleased content, skip leading blank lines
+  if (buf == "" && $0 == "") next
+  buf = buf $0 "\n"
+  next
+}
+printed_new == 1 {
+  printf "%s", buf
+  buf = ""
+  printed_new = 0
+}
+{ print }
+' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+
+# Update comparison links at bottom
+# [Unreleased]: .../compare/vOLD...HEAD -> .../compare/vNEW...HEAD
+sed -i.bak "s|\[Unreleased\]: \(.*\)/compare/v${PREV_VERSION}\.\.\.HEAD|[Unreleased]: \1/compare/${VERSION}...HEAD|" "$FILE"
+
+# Insert new version link before previous version link
+sed -i.bak "/^\[${PREV_VERSION}\]:/i\\
+[${VERSION_NUM}]: https://github.com/DecampsRenan/spm/compare/v${PREV_VERSION}...${VERSION}
+" "$FILE"
+
+# Clean up backup files from sed -i
+rm -f "${FILE}.bak"
+
+echo "CHANGELOG.md updated for ${VERSION}"


### PR DESCRIPTION
## Summary

Enforce changelog documentation discipline in PRs and automate changelog maintenance during releases.

- **CI validation**: New `changelog` job verifies [Unreleased] section has entries on every PR
- **Automated updates**: Release workflow now runs `update-changelog.sh` to promote unreleased entries into versioned sections with dates
- **Release safety**: Added guard to prevent infinite loops from changelog commits

The release workflow now commits changelog updates back to main before tagging, ensuring releases are documented when they ship.