### PR TITLE
fix: make changelog PR step non-fatal in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,5 +65,6 @@ jobs:
             git push origin "$BRANCH"
             gh pr create --base main --head "$BRANCH" \
               --title "chore: release ${{ steps.version.outputs.tag }}" \
-              --body "Automated changelog update for ${{ steps.version.outputs.tag }}"
+              --body "Automated changelog update for ${{ steps.version.outputs.tag }}" \
+              || echo "Warning: could not create PR for changelog update"
           fi


### PR DESCRIPTION
Make the changelog PR creation step resilient so release workflow doesn't fail if PR creation encounters issues. The `gh pr create` command now logs a warning on failure instead of breaking the entire release process.