### PR TITLE
feat: manual release workflow with semantic versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,24 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'chore: release')"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,18 +33,35 @@ jobs:
         run: |
           git fetch --tags
           LATEST=$(git tag -l 'v*' --sort=-v:refname | head -n1)
+          BUMP="${{ inputs.bump_type }}"
           if [ -z "$LATEST" ]; then
             NEXT="v0.1.0"
           else
             MAJOR=$(echo "$LATEST" | sed 's/v//' | cut -d. -f1)
             MINOR=$(echo "$LATEST" | sed 's/v//' | cut -d. -f2)
             PATCH=$(echo "$LATEST" | sed 's/v//' | cut -d. -f3)
-            NEXT="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+            case "$BUMP" in
+              major) NEXT="v$((MAJOR + 1)).0.0" ;;
+              minor) NEXT="v${MAJOR}.$((MINOR + 1)).0" ;;
+              *)     NEXT="v${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+            esac
           fi
           echo "tag=$NEXT" >> "$GITHUB_OUTPUT"
 
-      - name: Tag and push
+      - name: Update CHANGELOG
+        run: bash scripts/update-changelog.sh "${{ steps.version.outputs.tag }}"
+
+      - name: Commit CHANGELOG and tag
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet CHANGELOG.md; then
+            echo "No CHANGELOG changes to commit."
+          else
+            git add CHANGELOG.md
+            git commit -m "chore: release ${{ steps.version.outputs.tag }}"
+            git push origin HEAD:main
+          fi
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
 
@@ -47,24 +71,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update CHANGELOG
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          bash scripts/update-changelog.sh "${{ steps.version.outputs.tag }}"
-          if git diff --quiet CHANGELOG.md; then
-            echo "No CHANGELOG changes to commit."
-          else
-            BRANCH="release/${{ steps.version.outputs.tag }}"
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git checkout -b "$BRANCH"
-            git add CHANGELOG.md
-            git commit -m "chore: release ${{ steps.version.outputs.tag }}"
-            git push origin "$BRANCH"
-            gh pr create --base main --head "$BRANCH" \
-              --title "chore: release ${{ steps.version.outputs.tag }}" \
-              --body "Automated changelog update for ${{ steps.version.outputs.tag }}" \
-              || echo "Warning: could not create PR for changelog update"
-          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,30 @@ just build               # build binary
 
 ## Conventions
 
-- **Changelog**: Always update `CHANGELOG.md` when making user-facing changes. Add entries under `[Unreleased]` using the appropriate category (Added, Changed, Deprecated, Removed, Fixed, Security). Follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 - **README**: Keep `README.md` up to date when adding new commands, flags, or changing behavior.
 - **Tests**: Add or update tests for any new functionality in the corresponding `_test.go` files.
 - **Formatting**: A pre-commit hook runs `goimports` on staged Go files. Run `just setup` after cloning.
 - **CI**: GitHub Actions runs `go test ./... -v -race`, format checks, and cross-platform builds on every PR.
+
+## Changelog (OBLIGATOIRE)
+
+**Toute modification de code DOIT être accompagnée d'une mise à jour du CHANGELOG.**
+
+Avant de soumettre ou pousser des changements :
+1. Ouvrir `CHANGELOG.md`
+2. Ajouter une entrée sous `## [Unreleased]` dans la catégorie appropriée :
+   - **Added** : nouvelles fonctionnalités
+   - **Changed** : modifications de fonctionnalités existantes
+   - **Deprecated** : fonctionnalités bientôt supprimées
+   - **Removed** : fonctionnalités supprimées
+   - **Fixed** : corrections de bugs
+   - **Security** : corrections de vulnérabilités
+3. Le CI **bloquera le merge** si aucune entrée n'est présente dans `[Unreleased]`
+4. Ne jamais modifier les sections versionnées (ex: `[0.1.5]`), uniquement `[Unreleased]`
+
+## Release
+
+Les releases sont déclenchées **manuellement** via GitHub Actions :
+1. Aller dans **Actions > Release > Run workflow**
+2. Choisir le type de bump : `patch`, `minor`, ou `major`
+3. Le workflow calcule la version, met à jour le changelog, tag, et publie via GoReleaser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Release workflow is now manually triggered via `workflow_dispatch` with semantic version bump selection (patch/minor/major).
+- Changelog is committed directly to main during release instead of creating a separate PR.
+- Reinforced agent instructions in AGENTS.md to enforce changelog maintenance on feature branches.
+
 ## [0.1.5] - 2026-03-13
 
 ### Added


### PR DESCRIPTION
- Replace auto-release on push with workflow_dispatch trigger
- Add bump_type input (patch/minor/major) for semantic version control
- Commit changelog directly to main instead of creating a separate PR
- Reinforce AGENTS.md with mandatory changelog maintenance instructions

https://claude.ai/code/session_0157ggQ3pha88ygM9d2RkuoY