### PR TITLE
fix: stop background music on Ctrl+C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Background music now stops when the user presses Ctrl+C (SIGINT) during command execution.
+
 ## [0.2.0] - 2026-03-13
 
 ### Added

--- a/internal/audio/audio_playback.go
+++ b/internal/audio/audio_playback.go
@@ -192,7 +192,7 @@ func PlayMusicAndWait(fadeIn time.Duration) error {
 	}
 
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGTERM)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
 	<-sig
 
 	p.FadeOut(fadeOutDuration)

--- a/internal/audio/audio_test.go
+++ b/internal/audio/audio_test.go
@@ -1,6 +1,7 @@
 package audio
 
 import (
+	"os"
 	"testing"
 )
 
@@ -22,4 +23,67 @@ func TestDoubleStop(t *testing.T) {
 	// Double stop should not panic.
 	p.Stop()
 	p.Stop()
+}
+
+func TestVibesProcessStopImmediatelyNilCmd(t *testing.T) {
+	// StopImmediately on a VibesProcess with nil cmd should not panic.
+	// This is the case when SPM_DISABLE_AUDIO=1.
+	t.Setenv("SPM_DISABLE_AUDIO", "1")
+	v, err := StartVibes(0)
+	if err != nil {
+		t.Fatalf("StartVibes returned error: %v", err)
+	}
+	v.StopImmediately()
+}
+
+func TestVibesProcessFadeOutAndDetachNilCmd(t *testing.T) {
+	// FadeOutAndDetach on a VibesProcess with nil cmd should not panic.
+	t.Setenv("SPM_DISABLE_AUDIO", "1")
+	v, err := StartVibes(0)
+	if err != nil {
+		t.Fatalf("StartVibes returned error: %v", err)
+	}
+	v.FadeOutAndDetach()
+}
+
+func TestPlayNotificationDisabled(t *testing.T) {
+	t.Setenv("SPM_DISABLE_AUDIO", "1")
+	if err := PlayNotification(SoundSuccess); err != nil {
+		t.Fatalf("PlayNotification returned error: %v", err)
+	}
+}
+
+func TestNotificationSound(t *testing.T) {
+	tests := []struct {
+		success bool
+		vibes   bool
+		want    SoundName
+	}{
+		{true, true, SoundDing},
+		{true, false, SoundSuccess},
+		{false, true, SoundError},
+		{false, false, SoundError},
+	}
+	for _, tt := range tests {
+		got := NotificationSound(tt.success, tt.vibes)
+		if got != tt.want {
+			t.Errorf("NotificationSound(%v, %v) = %q, want %q", tt.success, tt.vibes, got, tt.want)
+		}
+	}
+}
+
+func TestStartVibesReturnsProcessWhenAudioEnabled(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping on CI — requires audio binary")
+	}
+	// When audio is not disabled, StartVibes should return a process with a non-nil cmd.
+	// We can't easily test this without the binary, so just verify the disabled path.
+	t.Setenv("SPM_DISABLE_AUDIO", "1")
+	v, err := StartVibes(0)
+	if err != nil {
+		t.Fatalf("StartVibes returned error: %v", err)
+	}
+	if v == nil {
+		t.Fatal("StartVibes returned nil VibesProcess")
+	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
 	"syscall"
 	"time"
@@ -51,6 +52,19 @@ func Run(args []string, dryRun bool, vibes bool, notify bool) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
+	// Intercept SIGINT so we can stop background tasks before exiting.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
+	go func() {
+		<-sigCh
+		if vibesProc != nil {
+			vibesProc.StopImmediately()
+		}
+		os.Exit(130)
+	}()
 
 	runErr := cmd.Run()
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,7 +1,12 @@
 package runner
 
 import (
+	"os"
+	"os/exec"
+	"runtime"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func TestRunDryRun(t *testing.T) {
@@ -97,5 +102,49 @@ func TestRunNotifyBinaryNotFound(t *testing.T) {
 	err := Run([]string{"nonexistent-binary-xyz-12345"}, false, false, true)
 	if err == nil {
 		t.Fatal("expected error for missing binary in notify mode")
+	}
+}
+
+// TestRunVibesSIGINTExits verifies that sending SIGINT to the runner process
+// causes it to exit with code 130 (the standard SIGINT exit code).
+// This uses the subprocess test pattern because Run calls os.Exit.
+func TestRunVibesSIGINTExits(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGINT test not supported on Windows")
+	}
+
+	if os.Getenv("TEST_RUN_VIBES_SIGINT") == "1" {
+		// We are the subprocess. Run a long sleep with vibes (audio disabled).
+		_ = Run([]string{"sleep", "60"}, false, true, false)
+		return
+	}
+
+	// Launch ourselves as a subprocess with the sentinel env var.
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunVibesSIGINTExits$")
+	cmd.Env = append(os.Environ(), "TEST_RUN_VIBES_SIGINT=1", "SPM_DISABLE_AUDIO=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start subprocess: %v", err)
+	}
+
+	// Give the subprocess time to set up the signal handler.
+	time.Sleep(500 * time.Millisecond)
+
+	// Send SIGINT to the subprocess.
+	if err := cmd.Process.Signal(syscall.SIGINT); err != nil {
+		t.Fatalf("failed to send SIGINT: %v", err)
+	}
+
+	err := cmd.Wait()
+	if err == nil {
+		t.Fatal("expected subprocess to exit with non-zero code")
+	}
+
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected ExitError, got %T: %v", err, err)
+	}
+
+	if exitErr.ExitCode() != 130 {
+		t.Errorf("expected exit code 130, got %d", exitErr.ExitCode())
 	}
 }


### PR DESCRIPTION
## Summary

- Intercepts SIGINT (Ctrl+C) in the runner to immediately stop background music before exiting
- Music subprocess now also handles SIGINT gracefully with fade-out
- Exits with code 130 (standard SIGINT exit code) after cleanup

## Test Plan

- Added TestRunVibesSIGINTExits to verify SIGINT causes exit code 130
- Added tests for VibesProcess nil-safety, notification sound logic, and audio disabling
- All existing tests pass with race detector enabled