### PR TITLE
feat: add progress TUI logging to remove and init commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Progress TUI logging (spinner + last log lines + elapsed time) for `spm remove` and `spm init` — previously these passed through raw package manager output. Both `init` steps (`pm init` and `pm install`) now show their own progress with appropriate labels ("Initializing"/"Installing dependencies").
+- Unit tests for the progress TUI output format covering all configurable labels.
+
+### Changed
+
+- The progress TUI now accepts a `Config` struct with configurable `Action`/`Done` labels instead of hardcoded "Installing"/"Installed". Each one-shot command shows its own verbs: `install`/`add`/`remove` → "Installing"/"Adding"/"Removing".
+
 ## [0.7.0] - 2026-04-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# spm — Agent instructions
+
+## Changelog updates (REQUIRED)
+
+After implementing any feature, change, fix, deprecation, removal, or
+security-related change in this repo, you **must** update `CHANGELOG.md`:
+
+1. Add an entry under the `## [Unreleased]` section.
+2. Use the correct category heading: `Added`, `Changed`, `Deprecated`,
+   `Removed`, `Fixed`, or `Security` (Keep a Changelog format).
+3. Write entries from the user's perspective — describe the observable
+   behavior change, not the implementation detail.
+4. Include the changelog edit in the same commit as the code change.
+
+This rule applies to **every** code change, including refactors that have
+user-visible effects, new tests for new behavior, and bug fixes. Skip the
+changelog only for purely internal cleanups with no user-facing impact
+(e.g. renaming an unexported variable, fixing a typo in a comment).

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
 	"github.com/decampsrenan/spm/internal/detector"
+	"github.com/decampsrenan/spm/internal/progress"
 	"github.com/decampsrenan/spm/internal/prompt"
 	"github.com/decampsrenan/spm/internal/resolver"
 	"github.com/decampsrenan/spm/internal/runner"
@@ -68,16 +70,40 @@ func runInit(args []string) error {
 		pm = selected
 	}
 
+	isTTY := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+
 	// Run <pm> init
 	initArgs := resolver.Resolve(pm, "init", extraArgs)
-	if err := runner.RunSubprocess(initArgs, dryRun); err != nil {
-		return fmt.Errorf("init failed: %w", err)
+	if isTTY && !rawOutput {
+		if err := progress.Run(progress.Config{
+			Args:   initArgs,
+			DryRun: dryRun,
+			Action: "Initializing",
+			Done:   "Initialized",
+		}); err != nil {
+			return fmt.Errorf("init failed: %w", err)
+		}
+	} else {
+		if err := runner.RunSubprocess(initArgs, dryRun); err != nil {
+			return fmt.Errorf("init failed: %w", err)
+		}
 	}
 
 	// Run <pm> install to generate lock file
 	installArgs := resolver.Resolve(pm, "install", nil)
-	if err := runner.RunSubprocess(installArgs, dryRun); err != nil {
-		return fmt.Errorf("install failed: %w", err)
+	if isTTY && !rawOutput {
+		if err := progress.Run(progress.Config{
+			Args:   installArgs,
+			DryRun: dryRun,
+			Action: "Installing dependencies",
+			Done:   "Dependencies installed",
+		}); err != nil {
+			return fmt.Errorf("install failed: %w", err)
+		}
+	} else {
+		if err := runner.RunSubprocess(installArgs, dryRun); err != nil {
+			return fmt.Errorf("install failed: %w", err)
+		}
 	}
 
 	if !dryRun {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -339,11 +339,29 @@ func run(command string, extraArgs []string) error {
 
 	args := resolver.Resolve(det.PM, command, extraArgs)
 
-	// Use progress TUI for install/add commands when stdout is a TTY and --raw is not set.
-	if command == "install" || command == "i" || command == "add" {
+	// Use progress TUI for one-shot commands when stdout is a TTY and --raw is not set.
+	type progressLabels struct {
+		action string
+		done   string
+	}
+	labels := map[string]progressLabels{
+		"install": {"Installing", "Installed"},
+		"i":       {"Installing", "Installed"},
+		"add":     {"Adding", "Added"},
+		"remove":  {"Removing", "Removed"},
+	}
+
+	if lbl, ok := labels[command]; ok {
 		isTTY := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
 		if isTTY && !rawOutput {
-			return progress.Run(args, dryRun, vibes, notify)
+			return progress.Run(progress.Config{
+				Args:   args,
+				DryRun: dryRun,
+				Vibes:  vibes,
+				Notify: notify,
+				Action: lbl.action,
+				Done:   lbl.done,
+			})
 		}
 	}
 

--- a/internal/progress/model.go
+++ b/internal/progress/model.go
@@ -14,7 +14,7 @@ import (
 
 const maxLogLines = 5
 
-// model is the bubbletea model for the install progress TUI.
+// model is the bubbletea model for the progress TUI.
 type model struct {
 	spinner   spinner.Model
 	lines     []string // ring buffer of last N output lines
@@ -24,6 +24,8 @@ type model struct {
 	err       error
 	width     int
 	msgCh     <-chan tea.Msg
+	action    string // e.g. "Installing"
+	doneLabel string // e.g. "Installed"
 }
 
 // Messages
@@ -37,7 +39,7 @@ type doneMsg struct {
 
 type timerTickMsg time.Time
 
-func newProgressModel(msgCh <-chan tea.Msg) model {
+func newProgressModel(msgCh <-chan tea.Msg, action, doneLabel string) model {
 	s := spinner.New()
 	s.Spinner = spinner.MiniDot
 	s.Style = lipgloss.NewStyle().Foreground(ui.ColorPrimary)
@@ -47,6 +49,8 @@ func newProgressModel(msgCh <-chan tea.Msg) model {
 		startTime: time.Now(),
 		width:     80,
 		msgCh:     msgCh,
+		action:    action,
+		doneLabel: doneLabel,
 	}
 }
 
@@ -103,7 +107,7 @@ func (m model) View() tea.View {
 	if m.done {
 		// Final summary
 		if m.exitCode == 0 {
-			status := ui.Success(fmt.Sprintf("Installed in %s", elapsed))
+			status := ui.Success(fmt.Sprintf("%s in %s", m.doneLabel, elapsed))
 			b.WriteString("  " + status + "\n")
 		} else {
 			status := ui.Error(fmt.Sprintf("Failed in %s", elapsed))
@@ -111,8 +115,9 @@ func (m model) View() tea.View {
 		}
 	} else {
 		// Spinner + status
-		status := fmt.Sprintf("  %s Installing...%s",
+		status := fmt.Sprintf("  %s %s...%s",
 			m.spinner.View(),
+			m.action,
 			ui.Dim(fmt.Sprintf("%"+fmt.Sprintf("%d", max(1, m.width-24))+"s", elapsed)),
 		)
 		b.WriteString(status + "\n")

--- a/internal/progress/model_test.go
+++ b/internal/progress/model_test.go
@@ -1,0 +1,237 @@
+package progress
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestViewShowsActionWhileRunning(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		done   string
+	}{
+		{"install", "Installing", "Installed"},
+		{"add", "Adding", "Added"},
+		{"remove", "Removing", "Removed"},
+		{"init", "Initializing", "Initialized"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch := make(chan tea.Msg)
+			m := newProgressModel(ch, tt.action, tt.done)
+			view := m.View()
+			if !strings.Contains(view.Content, tt.action+"...") {
+				t.Errorf("running view should contain %q, got: %s", tt.action+"...", view.Content)
+			}
+		})
+	}
+}
+
+func TestViewShowsDoneLabelOnSuccess(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		done   string
+	}{
+		{"install", "Installing", "Installed"},
+		{"add", "Adding", "Added"},
+		{"remove", "Removing", "Removed"},
+		{"init", "Initializing", "Initialized"},
+		{"deps", "Installing dependencies", "Dependencies installed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch := make(chan tea.Msg)
+			m := newProgressModel(ch, tt.action, tt.done)
+			m.done = true
+			m.exitCode = 0
+			view := m.View()
+			if !strings.Contains(view.Content, tt.done+" in ") {
+				t.Errorf("success view should contain %q, got: %s", tt.done+" in ", view.Content)
+			}
+		})
+	}
+}
+
+func TestViewShowsFailedOnError(t *testing.T) {
+	ch := make(chan tea.Msg)
+	m := newProgressModel(ch, "Installing", "Installed")
+	m.done = true
+	m.exitCode = 1
+	view := m.View()
+	if !strings.Contains(view.Content, "Failed in ") {
+		t.Errorf("error view should contain 'Failed in', got: %s", view.Content)
+	}
+	if strings.Contains(view.Content, "Installed") {
+		t.Errorf("error view should not contain 'Installed', got: %s", view.Content)
+	}
+}
+
+func TestViewDoesNotShowDoneLabelOnError(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		done   string
+	}{
+		{"install", "Installing", "Installed"},
+		{"remove", "Removing", "Removed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch := make(chan tea.Msg)
+			m := newProgressModel(ch, tt.action, tt.done)
+			m.done = true
+			m.exitCode = 1
+			view := m.View()
+			if strings.Contains(view.Content, tt.done) {
+				t.Errorf("error view should not contain %q, got: %s", tt.done, view.Content)
+			}
+		})
+	}
+}
+
+func TestDefaultLabels(t *testing.T) {
+	cfg := Config{Args: []string{"echo"}}
+	// Verify defaults are applied when labels are empty.
+	action := cfg.Action
+	if action == "" {
+		action = "Installing"
+	}
+	done := cfg.Done
+	if done == "" {
+		done = "Installed"
+	}
+
+	ch := make(chan tea.Msg)
+	m := newProgressModel(ch, action, done)
+
+	view := m.View()
+	if !strings.Contains(view.Content, "Installing...") {
+		t.Errorf("default running view should contain 'Installing...', got: %s", view.Content)
+	}
+
+	m.done = true
+	m.exitCode = 0
+	view = m.View()
+	if !strings.Contains(view.Content, "Installed in ") {
+		t.Errorf("default success view should contain 'Installed in', got: %s", view.Content)
+	}
+}
+
+func TestAddLine(t *testing.T) {
+	ch := make(chan tea.Msg)
+	m := newProgressModel(ch, "Installing", "Installed")
+
+	for i := 0; i < maxLogLines+3; i++ {
+		m.addLine("line")
+	}
+
+	if len(m.lines) != maxLogLines {
+		t.Errorf("expected %d lines in ring buffer, got %d", maxLogLines, len(m.lines))
+	}
+}
+
+func TestViewShowsLogLines(t *testing.T) {
+	ch := make(chan tea.Msg)
+	m := newProgressModel(ch, "Installing", "Installed")
+	m.addLine("npm warn deprecated")
+	m.addLine("added 42 packages")
+
+	view := m.View()
+	if !strings.Contains(view.Content, "npm warn deprecated") {
+		t.Errorf("view should contain log line, got: %s", view.Content)
+	}
+	if !strings.Contains(view.Content, "added 42 packages") {
+		t.Errorf("view should contain log line, got: %s", view.Content)
+	}
+}
+
+func TestViewTruncatesLongLines(t *testing.T) {
+	ch := make(chan tea.Msg)
+	m := newProgressModel(ch, "Installing", "Installed")
+	m.width = 20
+
+	longLine := "this is a very long line that should be truncated to fit"
+	m.addLine(longLine)
+
+	view := m.View()
+	// maxLen = width - 4 = 16, so truncated = 15 chars + "…"
+	if strings.Contains(view.Content, longLine) {
+		t.Error("view should truncate long lines")
+	}
+	if !strings.Contains(view.Content, "…") {
+		t.Error("truncated line should end with '…'")
+	}
+}
+
+func TestUpdateOutputLineMsg(t *testing.T) {
+	ch := make(chan tea.Msg, 1)
+	m := newProgressModel(ch, "Installing", "Installed")
+
+	updated, _ := m.Update(outputLineMsg("hello world"))
+	um := updated.(model)
+	if len(um.lines) != 1 || um.lines[0] != "hello world" {
+		t.Errorf("expected line 'hello world', got: %v", um.lines)
+	}
+}
+
+func TestUpdateOutputLineMsgTrimsWhitespace(t *testing.T) {
+	ch := make(chan tea.Msg, 1)
+	m := newProgressModel(ch, "Installing", "Installed")
+
+	updated, _ := m.Update(outputLineMsg("  hello  "))
+	um := updated.(model)
+	if len(um.lines) != 1 || um.lines[0] != "hello" {
+		t.Errorf("expected trimmed line 'hello', got: %v", um.lines)
+	}
+}
+
+func TestUpdateOutputLineMsgSkipsEmpty(t *testing.T) {
+	ch := make(chan tea.Msg, 1)
+	m := newProgressModel(ch, "Installing", "Installed")
+
+	updated, _ := m.Update(outputLineMsg("   "))
+	um := updated.(model)
+	if len(um.lines) != 0 {
+		t.Errorf("expected empty lines to be skipped, got: %v", um.lines)
+	}
+}
+
+func TestUpdateDoneMsg(t *testing.T) {
+	ch := make(chan tea.Msg)
+	m := newProgressModel(ch, "Removing", "Removed")
+
+	updated, _ := m.Update(doneMsg{exitCode: 0, err: nil})
+	um := updated.(model)
+	if !um.done {
+		t.Error("model should be done after doneMsg")
+	}
+	if um.exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", um.exitCode)
+	}
+}
+
+func TestUpdateDoneMsgWithError(t *testing.T) {
+	ch := make(chan tea.Msg)
+	m := newProgressModel(ch, "Removing", "Removed")
+
+	updated, _ := m.Update(doneMsg{exitCode: 1, err: nil})
+	um := updated.(model)
+	if !um.done {
+		t.Error("model should be done after doneMsg")
+	}
+	if um.exitCode != 1 {
+		t.Errorf("expected exit code 1, got %d", um.exitCode)
+	}
+
+	view := um.View()
+	if !strings.Contains(view.Content, "Failed in ") {
+		t.Errorf("error view should contain 'Failed in', got: %s", view.Content)
+	}
+}

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -17,10 +17,33 @@ import (
 
 const fadeDuration = 3 * time.Second
 
+// Config holds options for the progress TUI.
+type Config struct {
+	Args   []string
+	DryRun bool
+	Vibes  bool
+	Notify bool
+	Action string // shown during progress, e.g. "Installing"
+	Done   string // shown on success, e.g. "Installed"
+}
+
 // Run executes the given command with a progress TUI.
 // It pipes stdout/stderr through a bubbletea model that shows a spinner,
 // scrolling log lines, and elapsed time.
-func Run(args []string, dryRun bool, vibes bool, notify bool) error {
+func Run(cfg Config) error {
+	args := cfg.Args
+	dryRun := cfg.DryRun
+	vibes := cfg.Vibes
+	notify := cfg.Notify
+
+	action := cfg.Action
+	if action == "" {
+		action = "Installing"
+	}
+	done := cfg.Done
+	if done == "" {
+		done = "Installed"
+	}
 	if len(args) == 0 {
 		return fmt.Errorf("no command to run")
 	}
@@ -85,7 +108,7 @@ func Run(args []string, dryRun bool, vibes bool, notify bool) error {
 	}()
 
 	// Run TUI.
-	m := newProgressModel(msgCh)
+	m := newProgressModel(msgCh, action, done)
 	p := tea.NewProgram(m)
 
 	// Handle signals.

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -1,0 +1,55 @@
+package progress
+
+import (
+	"testing"
+)
+
+func TestRunEmptyArgs(t *testing.T) {
+	err := Run(Config{})
+	if err == nil {
+		t.Fatal("expected error for empty args")
+	}
+}
+
+func TestRunDryRun(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		done   string
+	}{
+		{"install defaults", "", ""},
+		{"custom labels", "Removing", "Removed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Run(Config{
+				Args:   []string{"echo", "hello"},
+				DryRun: true,
+				Action: tt.action,
+				Done:   tt.done,
+			})
+			if err != nil {
+				t.Fatalf("dry run returned error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunDryRunEmptyArgs(t *testing.T) {
+	err := Run(Config{DryRun: true})
+	if err == nil {
+		t.Fatal("expected error for empty args in dry-run mode")
+	}
+}
+
+func TestRunBinaryNotFound(t *testing.T) {
+	err := Run(Config{
+		Args:   []string{"nonexistent-binary-xyz-12345"},
+		Action: "Installing",
+		Done:   "Installed",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+}


### PR DESCRIPTION
Make the progress TUI labels configurable (action/done) instead of
hardcoded "Installing"/"Installed", then enable it for all one-shot
commands: install, add, remove, and init (both init + install steps).

https://claude.ai/code/session_01VhpBic8sMrVS9bFtbENWxY