### PR TITLE
fix(runner): drain terminal responses after child exits

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -38,10 +39,16 @@ func RunSubprocess(args []string, dryRun bool) error {
 	return cmd.Run()
 }
 
-// Run executes the given command. If dryRun is true, it prints what would be
-// run and returns nil. If vibes is true, it plays background music during
-// execution. If notify is true, it plays a notification sound on completion.
-// Otherwise it replaces the current process via syscall.Exec.
+// Run executes the given command as a subprocess. If dryRun is true, it prints
+// what would be run and returns nil. If vibes is true, it plays background
+// music during execution. If notify is true, it plays a notification sound on
+// completion.
+//
+// The command runs as a child (rather than via syscall.Exec) so we can drain
+// terminal response sequences after it exits. Long-running TUI-style commands
+// (e.g. turbo, vite) frequently query the terminal for capabilities; if they
+// are killed mid-query the response leaks into the shell's stdin and surfaces
+// as random characters at the next prompt.
 func Run(args []string, dryRun bool, vibes bool, notify bool) error {
 	if len(args) == 0 {
 		return fmt.Errorf("no command to run")
@@ -57,12 +64,6 @@ func Run(args []string, dryRun bool, vibes bool, notify bool) error {
 		return fmt.Errorf("%s not found in PATH: %w", args[0], err)
 	}
 
-	// Direct exec when no audio features needed.
-	if !vibes && !notify {
-		return syscall.Exec(bin, args, os.Environ())
-	}
-
-	// Child process mode: run command as subprocess so we can manage audio.
 	var vibesProc *audio.VibesProcess
 	if vibes {
 		var err error
@@ -77,29 +78,45 @@ func Run(args []string, dryRun bool, vibes bool, notify bool) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	// Intercept SIGINT so we can stop background tasks before exiting.
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(sigCh)
-
-	go func() {
-		s := <-sigCh
+	if err := cmd.Start(); err != nil {
 		if vibesProc != nil {
 			vibesProc.StopImmediately()
 		}
-		if s == syscall.SIGTERM {
-			os.Exit(143)
+		return fmt.Errorf("start command: %w", err)
+	}
+
+	// Catch SIGINT/SIGTERM so the parent stays alive long enough to drain the
+	// terminal after the child exits. Forward the signal to the child so it
+	// terminates whether the signal arrived via the foreground process group
+	// (Ctrl+C) or was addressed to spm directly.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	var caughtSig atomic.Int32
+	sigDone := make(chan struct{})
+	go func() {
+		defer close(sigDone)
+		s, ok := <-sigCh
+		if !ok {
+			return
 		}
-		os.Exit(130)
+		caughtSig.Store(int32(s.(syscall.Signal)))
+		if cmd.Process != nil {
+			_ = cmd.Process.Signal(s)
+		}
 	}()
 
-	runErr := cmd.Run()
+	runErr := cmd.Wait()
+	signal.Stop(sigCh)
+	close(sigCh)
+	<-sigDone
 
-	// Signal vibes to fade out (detached — won't block us).
+	// Drain any pending terminal response sequences (DECRPM, cursor pos, …)
+	// the child may have left in stdin after being killed mid-query.
+	ui.DrainTerminalResponses()
+
 	if vibesProc != nil {
 		if notify {
-			// When notify is set, kill music immediately so the
-			// notification sound is heard cleanly.
 			vibesProc.StopImmediately()
 		} else {
 			vibesProc.FadeOutAndDetach()
@@ -109,6 +126,13 @@ func Run(args []string, dryRun bool, vibes bool, notify bool) error {
 	if notify {
 		sound := audio.NotificationSound(runErr == nil, vibes)
 		_ = audio.PlayNotification(sound)
+	}
+
+	switch syscall.Signal(caughtSig.Load()) {
+	case syscall.SIGTERM:
+		os.Exit(143)
+	case syscall.SIGINT:
+		os.Exit(130)
 	}
 
 	if runErr != nil {


### PR DESCRIPTION
## Summary
- Switch `runner.Run` from `syscall.Exec` to a subprocess execution model so spm survives the child's exit
- Drain pending terminal escape responses (DECRPM, cursor position, …) from stdin after the child exits, fixing random characters appearing at the shell prompt after Ctrl+C on TUI-style commands like `turbo`
- Forward SIGINT/SIGTERM to the child and preserve the conventional exit codes (130 / 143)

## Test plan
- [x] `go test ./...` passes (existing SIGINT/SIGTERM exit-code tests still green)
- [ ] Manual: `spm dev` in a turbo project, Ctrl+C, confirm shell prompt is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)