### PR TITLE
fix: make Ctrl-C interrupt the install progress TUI

### DIFF
--- a/internal/progress/model.go
+++ b/internal/progress/model.go
@@ -16,14 +16,16 @@ const maxLogLines = 5
 
 // model is the bubbletea model for the install progress TUI.
 type model struct {
-	spinner   spinner.Model
-	lines     []string // ring buffer of last N output lines
-	startTime time.Time
-	done      bool
-	exitCode  int
-	err       error
-	width     int
-	msgCh     <-chan tea.Msg
+	spinner     spinner.Model
+	lines       []string // ring buffer of last N output lines
+	startTime   time.Time
+	done        bool
+	exitCode    int
+	err         error
+	interrupted bool
+	width       int
+	msgCh       <-chan tea.Msg
+	interrupt   func()
 }
 
 // Messages
@@ -37,7 +39,7 @@ type doneMsg struct {
 
 type timerTickMsg time.Time
 
-func newProgressModel(msgCh <-chan tea.Msg) model {
+func newProgressModel(msgCh <-chan tea.Msg, interrupt func()) model {
 	s := spinner.New()
 	s.Spinner = spinner.MiniDot
 	s.Style = lipgloss.NewStyle().Foreground(ui.ColorPrimary)
@@ -47,6 +49,7 @@ func newProgressModel(msgCh <-chan tea.Msg) model {
 		startTime: time.Now(),
 		width:     80,
 		msgCh:     msgCh,
+		interrupt: interrupt,
 	}
 }
 
@@ -60,6 +63,16 @@ func (m model) Init() tea.Cmd {
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+
+	case tea.KeyPressMsg:
+		if msg.String() == "ctrl+c" {
+			m.interrupted = true
+			if m.interrupt != nil {
+				m.interrupt()
+			}
+			return m, tea.Quit
+		}
+		return m, nil
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -44,9 +44,12 @@ func Run(args []string, dryRun bool, vibes bool, notify bool) error {
 		}
 	}
 
-	// Set up subprocess with piped output.
+	// Set up subprocess with piped output. We deliberately do NOT inherit
+	// stdin: bubbletea owns stdin in raw mode and needs to receive Ctrl+C
+	// as a keystroke. Sharing stdin with the child would let the child
+	// consume key bytes (including Ctrl+C) and prevent the TUI from
+	// reacting to them.
 	cmd := exec.Command(bin, args[1:]...)
-	cmd.Stdin = os.Stdin
 
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -84,17 +87,26 @@ func Run(args []string, dryRun bool, vibes bool, notify bool) error {
 		close(msgCh)
 	}()
 
-	// Run TUI.
-	m := newProgressModel(msgCh)
+	// Run TUI. The model handles Ctrl+C as a key event (bubbletea puts the
+	// terminal in raw mode, so SIGINT is not delivered) and calls interrupt
+	// to kill the subprocess.
+	interrupt := func() {
+		_ = cmd.Process.Kill()
+	}
+	m := newProgressModel(msgCh, interrupt)
 	p := tea.NewProgram(m)
 
-	// Handle signals.
+	// Handle SIGTERM (and SIGINT, in case the TUI is not in raw mode for any
+	// reason — e.g. running with redirected stdin).
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
 
 	go func() {
-		s := <-sigCh
+		s, ok := <-sigCh
+		if !ok {
+			return
+		}
 		if vibesProc != nil {
 			vibesProc.StopImmediately()
 		}
@@ -116,17 +128,25 @@ func Run(args []string, dryRun bool, vibes bool, notify bool) error {
 	// Extract exit code from final model.
 	fm, ok := finalModel.(model)
 	exitCode := 0
+	interrupted := false
 	if ok {
 		exitCode = fm.exitCode
+		interrupted = fm.interrupted
 	}
 
 	// Stop music.
 	if vibesProc != nil {
-		if notify {
+		if notify && !interrupted {
+			vibesProc.StopImmediately()
+		} else if interrupted {
 			vibesProc.StopImmediately()
 		} else {
 			vibesProc.FadeOutAndDetach()
 		}
+	}
+
+	if interrupted {
+		os.Exit(130)
 	}
 
 	// Play notification sound.

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -9,9 +9,12 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// Color palette — adaptive to dark/light terminal backgrounds.
-
-var hasDarkBG = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+// hasDarkBG controls light/dark color choices. We default to dark because
+// most terminals are dark and lipgloss's HasDarkBackground query reads from
+// stdin at package-init time, which races with (and can break) any later TUI
+// input reader — including bubbletea's. TUI screens that need accurate
+// detection should listen for tea.BackgroundColorMsg in their Update.
+var hasDarkBG = true
 
 func lightDark(light, dark string) color.Color {
 	if hasDarkBG {


### PR DESCRIPTION
## Summary
- `lipgloss.HasDarkBackground(os.Stdin, os.Stdout)` ran at package init in `internal/ui/ui.go`, leaving stdin in a state where bubbletea's input reader received no bytes — so Ctrl-C (delivered as a key event in raw mode, not as SIGINT) was silently dropped during `spm install`.
- Default `hasDarkBG` to `true` instead of querying at init, handle `ctrl+c` in the progress model to kill the subprocess and exit 130, and stop sharing `os.Stdin` with the child so bubbletea owns it cleanly.

## Test plan
- [x] `go test ./...` passes
- [x] Verified with a PTY harness: before the fix, ^C timed out; after, the process exits in ~2s with code 130
- [ ] Manually run `spm install` in a real terminal and confirm Ctrl-C aborts promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)